### PR TITLE
Changes so node-irsdk works with Electron 9.x 

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,4 @@
-﻿{
+{
   "targets": [
     {
       "target_name": "IrSdkNodeBindings",

--- a/src/cpp/IrSdkBindingHelpers.cpp
+++ b/src/cpp/IrSdkBindingHelpers.cpp
@@ -49,7 +49,7 @@ Local<Value> NodeIrSdk::convertTelemetryVarToObject(IRSDKWrapper::TelemetryVar &
     Local<Array> arr = Nan::New<Array>(var.header->count);
     for (int i = 0; i < var.header->count; ++i)
     {
-      arr->Set(i, convertTelemetryValueToObject(var, i));
+      Nan::Set(arr, i, convertTelemetryValueToObject(var, i));
     }
     return arr;
   }

--- a/src/node-irsdk.js
+++ b/src/node-irsdk.js
@@ -1,4 +1,4 @@
-var IrSdkNodeWrapper = require('../build/Release/IrSdkNodeBindings')
+var IrSdkNodeWrapper = require('../build/Release/IrSdkNodeBindings.node')
 var JsIrSdk = require('./JsIrSdk')
 
 /**


### PR DESCRIPTION
Based on findings of @heimdallexus and @martinguder.
Related to #86 and #32

Make sure to rebuild your project.