### PR TITLE
Hidden Character caused build error with gyp 8.4.1

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,4 @@
-﻿{
+{
   "targets": [
     {
       "target_name": "IrSdkNodeBindings",


### PR DESCRIPTION
```
398 error   File "binding.gyp", line 1
398 error     \ufeff{
398 error     ^
398 error SyntaxError: invalid non-printable character U+FEFF
```